### PR TITLE
Add GitHub actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,42 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 0 * * *' # daily at 00:00 UTC
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y -qq update
+          sudo apt-get -y --no-install-recommends install \
+            cmake \
+            build-essential
+
+      - name: Create build environment
+        run: cmake -S . -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        run: ctest --test-dir build/test
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build_folder
+          path: |
+            build/
+            !build/**/*google*
+            !build/**/*gmock*
+            !build/**/*gtest*
+        if: always()
+

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,32 @@
+name: lint
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y -qq update
+          sudo apt-get -y --no-install-recommends install clang-format
+
+      - name: Run clang-format
+        shell: bash
+        run: bash format.sh
+
+      - name: Set up git config
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@users.noreply.github.com"
+
+      - name: Commit linting fixes
+        run: |
+          git add .
+          git commit -m "[bot] clang-format lint fixes" || echo "No changes to commit"


### PR DESCRIPTION
https://github.com/aprotyas/Reversi/commit/0648987c95c86adac6cca9c50410999ac1991532 introduces a workflow that builds and runs the (pitiful) test(s).
https://github.com/aprotyas/Reversi/commit/785876681554197def3e42959e14f5b916d8cda6 does linting with clang-format.

Closes #2.