### PR TITLE
Trigger github actions on push only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,7 @@
 name: ci
 
 on:
-  pull_request:
   push:
-  schedule:
-    - cron: '0 0 * * *' # daily at 00:00 UTC
 
 jobs:
   build-and-test:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,7 +1,6 @@
 name: lint
 
 on:
-  pull_request:
   push:
 
 jobs:


### PR DESCRIPTION
Indirectly fixes #6 because we don't bother for the `HEAD` ref on a PR trigger anymore.

Push-only trigger of Github actions is sufficient CI coverage for the project. It's also not a problem since CI only runs for 2 minutes every time.